### PR TITLE
Fix cache issues with overlapping `declare_{file,directory}`.

### DIFF
--- a/toolchains/crosscompilers/BUILD
+++ b/toolchains/crosscompilers/BUILD
@@ -37,10 +37,6 @@ crosstoolng(
     name = "avr-toolchain",
     ct_ng = "ct-ng",
     defconfig = "avr/defconfig",
-    out_binaries = [
-        "avr-objcopy",
-        "avr-objdump",
-    ],
     tags = ["manual"],
     tarballs = ["@{}//file".format(d) for d in [
         "zlib-1.2.11",


### PR DESCRIPTION
Use of an external cache (or at least `--disk_cache`) is really useful for locally-built toolchains, as building the toolchain is expensive, and it is useful to share this work across repositories. However, there is a Bazel bug that prevents this from working properly.

As noted by bazelbuild/bazel#12067, if there is an output directory declared with `ctx.actions.declare_directory()`, but also one or more files within that same directory declared with `ctx.actions.declare_file()`, these "overlapping" declarations confuse Bazel's external caching implementation. (This had attempted to be fixed, but didn't completely solve it.)

Removing all uses of `declare_file()` seems to fix it; this functionality doesn't appear to be used anyway.

To reproduce, start with a clean repo and cache, populate an external cache, clean, and then try to build again from that cache:
```
$ bazel build --disk_cache=~/.cache/bazel/disk_cache //...
$ bazel clean
$ bazel build --disk_cache=~/.cache/bazel/disk_cache //...
[...]
WARNING: Remote Cache:
java.io.FileNotFoundException: /home/rpwoodbu/.cache/bazel/_bazel_rpwoodbu/896406ed50deb5f982c04ef66e90fccb/execroot/__main__/bazel-out/k8-opt-exec-2B5CBBC6-ST-e846b08c7501/bin/toolchains/crosscompilers/avr-toolchain/avr/bin/ar.tmp (No such file or directory)
[...]
```

This Bazel bug doesn't break the build, but it does force it to rebuild the toolchain, which takes a very long time.

This had presumably been fixed upstream, but running Bazel 6.0.0 still shows a bug, albeit different:
```
WARNING: Remote Cache:
java.io.IOException: /home/rpwoodbu/.cache/bazel/_bazel_rpwoodbu/896406ed50deb5f982c04ef66e90fccb/execroot/__main__/bazel-out/k8-opt-exec-2B5CBBC6-ST-e846b08c7501/bin/toolchains/crosscompilers/avr-toolchain/lib/gcc/avr/7.4.0/plugin/libcc1plugin.so (File exists)
```